### PR TITLE
Unitary header

### DIFF
--- a/qiskit/providers/qrack/backends/qasm_simulator.py
+++ b/qiskit/providers/qrack/backends/qasm_simulator.py
@@ -485,10 +485,11 @@ class QasmSimulator(BaseBackend):
                 if operation.name == 'id' or operation.name == 'barrier':
                     continue
 
-                if hasattr(operation, 'conditional') or (operation.name == 'reset') or (operation.name == 'initialize'):
+                if hasattr(operation, 'conditional') or operation.name == 'reset' or operation.name == 'initialize':
                     if is_initializing:
                         continue
-                    nonunitary_start = opcount
+                    if operation.name != 'reset':
+                        nonunitary_start = opcount
                     shotLoopMax = self._shots
                     shotsPerLoop = 1
                     self._sample_measure = False

--- a/qiskit/providers/qrack/backends/qasm_simulator.py
+++ b/qiskit/providers/qrack/backends/qasm_simulator.py
@@ -513,7 +513,7 @@ class QasmSimulator(BaseBackend):
 
         is_unitary_preamble = False
 
-        if nonunitary_start <= 1 or shotLoopMax != 1:
+        if self._sample_measure:
             nonunitary_start = 0
         else:
             is_unitary_preamble = True

--- a/qiskit/providers/qrack/backends/qasm_simulator.py
+++ b/qiskit/providers/qrack/backends/qasm_simulator.py
@@ -365,7 +365,6 @@ class QasmSimulator(BaseBackend):
         self._configuration = configuration
         self._number_of_qubits = None
         self._number_of_cbits = None
-        self._statevector = None
         self._results = {}
         self._shots = {}
         self._local_random = np.random.RandomState()
@@ -453,7 +452,11 @@ class QasmSimulator(BaseBackend):
         """
         self._number_of_qubits = experiment.header.n_qubits
         self._number_of_cbits = experiment.header.memory_slots
-        self._statevector = 0
+        self._sample_qubits = []
+        self._sample_clbits = []
+        self._sample_cregbits = []
+        self.__memory = []
+        self._sample_measure = True
 
         if hasattr(experiment.config, 'seed'):
             seed = experiment.config.seed
@@ -465,26 +468,27 @@ class QasmSimulator(BaseBackend):
             seed = np.random.randint(2147483647, dtype='int32')
         self._local_random.seed(seed)
 
-        sample_qubits = []
-        sample_clbits = []
-        sample_cregbits = []
-        memory = []
-
         start = time.time()
 
-        shotLoopMax = 1
         shotsPerLoop = self._shots
-        self._sample_measure = True
+        shotLoopMax = 1
+
         did_measure = False
         is_initializing = True
+        opcount = -1
+        nonunitary_start = 0
+
         if self._shots != 1:
             for operation in experiment.instructions:
+                opcount = opcount + 1
+
                 if operation.name == 'id' or operation.name == 'barrier':
                     continue
 
                 if hasattr(operation, 'conditional') or (operation.name == 'reset') or (operation.name == 'initialize'):
                     if is_initializing:
                         continue
+                    nonunitary_start = opcount
                     shotLoopMax = self._shots
                     shotsPerLoop = 1
                     self._sample_measure = False
@@ -494,6 +498,8 @@ class QasmSimulator(BaseBackend):
                 is_initializing = False
 
                 if operation.name == 'measure':
+                    if nonunitary_start == 0:
+                        nonunitary_start = opcount
                     did_measure = True
                 elif did_measure:
                     shotLoopMax = self._shots
@@ -502,202 +508,89 @@ class QasmSimulator(BaseBackend):
                     logger.info('Cannot sample; must repeat circuit per shot. If possible, consider removing "reset," "initialize," and conditionals, setting shots=1, and/or only measuring at the end of the circuit.')
                     break
 
-        for shot in range(shotLoopMax):
+        preamble_classical_memory = 0
+        preamble_classical_register = 0
+
+        is_unitary_preamble = False
+
+        if nonunitary_start <= 1 or shotLoopMax != 1:
+            nonunitary_start = 0
+        else:
+            is_unitary_preamble = True
+            self._sample_measure = True
             try:
-                sim = qrack_controller_factory()
-                sim.initialize_qreg(self._configuration.opencl,
-                                    self._configuration.schmidt_decompose,
-                                    self._configuration.paging,
-                                    self._configuration.stabilizer,
-                                    self._number_of_qubits,
-                                    self._configuration.opencl_device_id,
-                                    self._configuration.opencl_multi,
-                                    self._configuration.normalize,
-                                    self._configuration.zero_threshold)
+                self._sim = qrack_controller_factory()
+                self._sim.initialize_qreg(self._configuration.opencl,
+                                          self._configuration.schmidt_decompose,
+                                          self._configuration.paging,
+                                          self._configuration.stabilizer,
+                                          self._number_of_qubits,
+                                          self._configuration.opencl_device_id,
+                                          self._configuration.opencl_multi,
+                                          self._configuration.normalize,
+                                          self._configuration.zero_threshold)
             except OverflowError:
                 raise QrackError('too many qubits')
 
             self._classical_memory = 0
             self._classical_register = 0
 
-            for operation in experiment.instructions:
-                name = operation.name
+            for operation in experiment.instructions[:nonunitary_start]:
+                self._apply_op(operation, shotsPerLoop)
 
-                if name == 'id':
-                    logger.info('Identity gates are ignored.')
-                    # Skip measurement logic
-                    continue
-                elif name == 'barrier':
-                    logger.info('Barrier gates are ignored.')
-                    # Skip measurement logic
-                    continue
+            preamble_classical_memory = self._classical_memory
+            preamble_classical_register = self._classical_register
+            self._sample_measure = False
 
-                if (name != 'measure' or hasattr(operation, 'conditional')) and len(sample_qubits) > 0:
-                    if self._sample_measure:
-                        memory = self._add_sample_measure(sample_qubits, sample_clbits, sim, shotsPerLoop)
-                    else:
-                        self._add_qasm_measure(sample_qubits, sample_clbits, sim, sample_cregbits)
-                    sample_qubits = []
-                    sample_clbits = []
-                    sample_cregbits = []
+        preamble_sim = self._sim if is_unitary_preamble else None
 
-                conditional = getattr(operation, 'conditional', None)
-                if isinstance(conditional, int):
-                    conditional_bit_set = (self._classical_register >> conditional) & 1
-                    if not conditional_bit_set:
-                        continue
-                elif conditional is not None:
-                    mask = int(operation.conditional.mask, 16)
-                    if mask > 0:
-                        value = self._classical_memory & mask
-                        while (mask & 0x1) == 0:
-                            mask >>= 1
-                            value >>= 1
-                        if value != int(operation.conditional.val, 16):
-                            continue
+        for shot in range(shotLoopMax):
+            if not is_unitary_preamble:
+                try:
+                    self._sim = qrack_controller_factory()
+                    self._sim.initialize_qreg(self._configuration.opencl,
+                                              self._configuration.schmidt_decompose,
+                                              self._configuration.paging,
+                                              self._configuration.stabilizer,
+                                              self._number_of_qubits,
+                                              self._configuration.opencl_device_id,
+                                              self._configuration.opencl_multi,
+                                              self._configuration.normalize,
+                                              self._configuration.zero_threshold)
+                except OverflowError:
+                    raise QrackError('too many qubits')
+                self._classical_memory = 0
+                self._classical_register = 0
+            else:
+                self._sim = preamble_sim.clone()
+                self._classical_memory = preamble_classical_memory
+                self._classical_register = preamble_classical_register
 
-                if (name == 'u1') or (name == 'p'):
-                    sim.u1(operation.qubits, operation.params)
-                elif name == 'u2':
-                    sim.u2(operation.qubits, operation.params)
-                elif (name == 'u3') or (name == 'u'):
-                    sim.u(operation.qubits, operation.params)
-                elif name == 'r':
-                    sim.u(operation.qubits, [operation.params[0], operation.params[1] - np.pi/2, -operation.params[1] + np.pi/2])
-                elif name == 'unitary':
-                    if (len(operation.qubits) != len(operation.params)) or (len(operation.params) != 2):
-                        raise QrackError('Invalid unitary instruction. Qrack only supports single qubit targets for "unitary."')
-                    for qbi in range(len(operation.qubits)):
-                        sim.unitary1qb([operation.qubits[qbi]], operation.params[qbi])
-                elif name == 'cx':
-                    sim.cx(operation.qubits)
-                elif name == 'cz':
-                    sim.cz(operation.qubits)
-                elif name == 'ch':
-                    sim.ch(operation.qubits)
-                elif name == 'x':
-                    sim.x(operation.qubits)
-                elif name == 'sx':
-                    sim.sx(operation.qubits)
-                elif name == 'y':
-                    sim.y(operation.qubits)
-                elif name == 'z':
-                    sim.z(operation.qubits)
-                elif name == 'h':
-                    sim.h(operation.qubits)
-                elif name == 'rx':
-                    sim.rx(operation.qubits, operation.params)
-                elif name == 'ry':
-                    sim.ry(operation.qubits, operation.params)
-                elif name == 'rz':
-                    sim.rz(operation.qubits, operation.params)
-                elif name == 's':
-                    sim.s(operation.qubits)
-                elif name == 'sdg':
-                    sim.sdg(operation.qubits)
-                elif name == 't':
-                    sim.t(operation.qubits)
-                elif name == 'tdg':
-                    sim.tdg(operation.qubits)
-                elif name == 'swap':
-                    sim.swap(operation.qubits[0], operation.qubits[1])
-                elif name == 'ccx':
-                    sim.cx(operation.qubits)
-                elif name == 'cu1':
-                    sim.cu1(operation.qubits, operation.params)
-                elif name == 'cu2':
-                    sim.cu2(operation.qubits, operation.params)
-                elif name == 'cu3':
-                    sim.cu(operation.qubits, operation.params)
-                elif name == 'cswap':
-                    sim.cswap(operation.qubits)
-                elif name == 'mcx':
-                    sim.cx(operation.qubits)
-                elif name == 'mcy':
-                    sim.cy(operation.qubits)
-                elif name == 'mcz':
-                    sim.cz(operation.qubits)
-                elif name == 'initialize':
-                    sim.initialize(operation.qubits, operation.params)
-                elif name == 'cu1':
-                    sim.cu1(operation.qubits, operation.params)
-                elif name == 'cu2':
-                    sim.cu2(operation.qubits, operation.params)
-                elif name == 'cu3':
-                    sim.cu(operation.qubits, operation.params)
-                elif name == 'mcswap':
-                    sim.cswap(operation.qubits)
-                elif name == 'multiplexer':
-                    if (len(operation.params) != 1 << (len(operation.qubits) - 1)) or (len(operation.params[0]) != 2):
-                        raise QrackError('Invalid multiplexer instruction. Qrack only supports single qubit targets for multiplexers.')
-                    sim.multiplexer(operation.qubits, len(operation.qubits) - 1, operation.params)
-                elif name == 'reset':
-                    sim.reset(operation.qubits[0])
-                elif name == 'measure':
-                    cregbits = operation.register if hasattr(operation, 'register') else len(operation.qubits) * [-1]
-                    sample_qubits.append(operation.qubits)
-                    sample_clbits.append(operation.memory)
-                    sample_cregbits.append(cregbits)
-                elif name == 'bfunc':
-                    mask = int(operation.mask, 16)
-                    relation = operation.relation
-                    val = int(operation.val, 16)
+            for operation in experiment.instructions[nonunitary_start:]:
+                self._apply_op(operation, shotsPerLoop)
 
-                    cregbit = operation.register
-                    cmembit = operation.memory if hasattr(operation, 'memory') else None
-
-                    compared = (self._classical_register & mask) - val
-
-                    if relation == '==':
-                        outcome = (compared == 0)
-                    elif relation == '!=':
-                        outcome = (compared != 0)
-                    elif relation == '<':
-                        outcome = (compared < 0)
-                    elif relation == '<=':
-                        outcome = (compared <= 0)
-                    elif relation == '>':
-                        outcome = (compared > 0)
-                    elif relation == '>=':
-                        outcome = (compared >= 0)
-                    else:
-                        raise QrackError('Invalid boolean function relation.')
-
-                    # Store outcome in register and optionally memory slot
-                    regbit = 1 << cregbit
-                    self._classical_register = \
-                        (self._classical_register & (~regbit)) | (int(outcome) << cregbit)
-                    if cmembit is not None:
-                        membit = 1 << cmembit
-                        self._classical_memory = \
-                            (self._classical_memory & (~membit)) | (int(outcome) << cmembit)
-                else:
-                    backend = self.name()
-                    err_msg = '{0} encountered unrecognized operation "{1}"'
-                    raise QrackError(err_msg.format(backend, operation))
-
-            if len(sample_qubits) > 0:
+            if len(self._sample_qubits) > 0:
                 if self._sample_measure:
-                    memory = self._add_sample_measure(sample_qubits, sample_clbits, sim, shotsPerLoop)
+                    self.__memory = self._add_sample_measure(self._sample_qubits, self._sample_clbits, shotsPerLoop)
                 else:
-                    self._add_qasm_measure(sample_qubits, sample_clbits, sim, sample_cregbits)
-                sample_qubits = []
-                sample_clbits = []
-                sample_cregbits = []
+                    self._add_qasm_measure(self._sample_qubits, self._sample_clbits, self._sample_cregbits)
+                self._sample_qubits = []
+                self._sample_clbits = []
+                self._sample_cregbits = []
 
             if not self._sample_measure:
                 # Turn classical_memory (int) into bit string and pad zero for unused cmembits
-                memory.append(hex(int(bin(self._classical_memory)[2:], 2)))
+                self.__memory.append(hex(int(bin(self._classical_memory)[2:], 2)))
 
         end = time.time()
 
-        # amps = sim.amplitudes().round(self._chop_threshold)
+        # amps = self._sim.amplitudes().round(self._chop_threshold)
         # amps = np.stack((amps.real, amps.imag), axis=-1)
 
-        data = {'counts': dict(Counter(memory))}
+        data = {'counts': dict(Counter(self.__memory))}
 
         if self._memory:
-            data['memory'] = memory
+            data['memory'] = self.__memory
 
         return {
             'name': experiment.header.name,
@@ -712,7 +605,164 @@ class QasmSimulator(BaseBackend):
         }
 
     #@profile
-    def _add_sample_measure(self, sample_qubits, sample_clbits, sim, num_samples):
+    def _apply_op(self, operation, shotsPerLoop):
+        name = operation.name
+
+        if name == 'id':
+            logger.info('Identity gates are ignored.')
+            # Skip measurement logic
+            return
+        elif name == 'barrier':
+            logger.info('Barrier gates are ignored.')
+            # Skip measurement logic
+            return
+
+        if (name != 'measure' or hasattr(operation, 'conditional')) and len(self._sample_qubits) > 0:
+            if self._sample_measure:
+                self._memory = self._add_sample_measure(self._sample_qubits, sample_clbits, sim, shotsPerLoop)
+            else:
+                self._add_qasm_measure(self._sample_qubits, self._sample_clbits, self._sample_cregbits)
+            self._sample_qubits = []
+            self._sample_clbits = []
+            self._sample_cregbits = []
+
+        conditional = getattr(operation, 'conditional', None)
+        if isinstance(conditional, int):
+            conditional_bit_set = (self._classical_register >> conditional) & 1
+            if not conditional_bit_set:
+                return
+        elif conditional is not None:
+            mask = int(operation.conditional.mask, 16)
+            if mask > 0:
+                value = self._classical_memory & mask
+                while (mask & 0x1) == 0:
+                    mask >>= 1
+                    value >>= 1
+                if value != int(operation.conditional.val, 16):
+                    return
+
+        if (name == 'u1') or (name == 'p'):
+            self._sim.u1(operation.qubits, operation.params)
+        elif name == 'u2':
+            self._sim.u2(operation.qubits, operation.params)
+        elif (name == 'u3') or (name == 'u'):
+            self._sim.u(operation.qubits, operation.params)
+        elif name == 'r':
+            self._sim.u(operation.qubits, [operation.params[0], operation.params[1] - np.pi/2, -operation.params[1] + np.pi/2])
+        elif name == 'unitary':
+            if (len(operation.qubits) != len(operation.params)) or (len(operation.params) != 2):
+                raise QrackError('Invalid unitary instruction. Qrack only supports single qubit targets for "unitary."')
+            for qbi in range(len(operation.qubits)):
+                self._sim.unitary1qb([operation.qubits[qbi]], operation.params[qbi])
+        elif name == 'cx':
+            self._sim.cx(operation.qubits)
+        elif name == 'cz':
+            self._sim.cz(operation.qubits)
+        elif name == 'ch':
+            self._sim.ch(operation.qubits)
+        elif name == 'x':
+            self._sim.x(operation.qubits)
+        elif name == 'sx':
+            self._sim.sx(operation.qubits)
+        elif name == 'y':
+            self._sim.y(operation.qubits)
+        elif name == 'z':
+            self._sim.z(operation.qubits)
+        elif name == 'h':
+            self._sim.h(operation.qubits)
+        elif name == 'rx':
+            self._sim.rx(operation.qubits, operation.params)
+        elif name == 'ry':
+            self._sim.ry(operation.qubits, operation.params)
+        elif name == 'rz':
+            self._sim.rz(operation.qubits, operation.params)
+        elif name == 's':
+            self._sim.s(operation.qubits)
+        elif name == 'sdg':
+            self._sim.sdg(operation.qubits)
+        elif name == 't':
+            self._sim.t(operation.qubits)
+        elif name == 'tdg':
+            self._sim.tdg(operation.qubits)
+        elif name == 'swap':
+            self._sim.swap(operation.qubits[0], operation.qubits[1])
+        elif name == 'ccx':
+            self._sim.cx(operation.qubits)
+        elif name == 'cu1':
+            self._sim.cu1(operation.qubits, operation.params)
+        elif name == 'cu2':
+            self._sim.cu2(operation.qubits, operation.params)
+        elif name == 'cu3':
+            self._sim.cu(operation.qubits, operation.params)
+        elif name == 'cswap':
+            self._sim.cswap(operation.qubits)
+        elif name == 'mcx':
+            self._sim.cx(operation.qubits)
+        elif name == 'mcy':
+            self._sim.cy(operation.qubits)
+        elif name == 'mcz':
+            self._sim.cz(operation.qubits)
+        elif name == 'initialize':
+            self._sim.initialize(operation.qubits, operation.params)
+        elif name == 'cu1':
+            self._sim.cu1(operation.qubits, operation.params)
+        elif name == 'cu2':
+            self._sim.cu2(operation.qubits, operation.params)
+        elif name == 'cu3':
+            self._sim.cu(operation.qubits, operation.params)
+        elif name == 'mcswap':
+            self._sim.cswap(operation.qubits)
+        elif name == 'multiplexer':
+            if (len(operation.params) != 1 << (len(operation.qubits) - 1)) or (len(operation.params[0]) != 2):
+                raise QrackError('Invalid multiplexer instruction. Qrack only supports single qubit targets for multiplexers.')
+            self._sim.multiplexer(operation.qubits, len(operation.qubits) - 1, operation.params)
+        elif name == 'reset':
+            self._sim.reset(operation.qubits[0])
+        elif name == 'measure':
+            cregbits = operation.register if hasattr(operation, 'register') else len(operation.qubits) * [-1]
+            self._sample_qubits.append(operation.qubits)
+            self._sample_clbits.append(operation.memory)
+            self._sample_cregbits.append(cregbits)
+        elif name == 'bfunc':
+            mask = int(operation.mask, 16)
+            relation = operation.relation
+            val = int(operation.val, 16)
+
+            cregbit = operation.register
+            cmembit = operation.memory if hasattr(operation, 'memory') else None
+
+            compared = (self._classical_register & mask) - val
+
+            if relation == '==':
+                outcome = (compared == 0)
+            elif relation == '!=':
+                outcome = (compared != 0)
+            elif relation == '<':
+                outcome = (compared < 0)
+            elif relation == '<=':
+                outcome = (compared <= 0)
+            elif relation == '>':
+                outcome = (compared > 0)
+            elif relation == '>=':
+                outcome = (compared >= 0)
+            else:
+                raise QrackError('Invalid boolean function relation.')
+
+            # Store outcome in register and optionally memory slot
+            regbit = 1 << cregbit
+            self._classical_register = \
+                (self._classical_register & (~regbit)) | (int(outcome) << cregbit)
+            if cmembit is not None:
+                membit = 1 << cmembit
+                self._classical_memory = \
+                    (self._classical_memory & (~membit)) | (int(outcome) << cmembit)
+        else:
+            backend = self.name()
+            err_msg = '{0} encountered unrecognized operation "{1}"'
+            raise QrackError(err_msg.format(backend, operation))
+
+    #@profile
+    def _add_sample_measure(self, sample_qubits, sample_clbits, num_samples):
         """Generate memory samples from current statevector.
         Taken almost straight from the terra source code.
         Args:
@@ -731,7 +781,7 @@ class QasmSimulator(BaseBackend):
         # If we only want one sample, it's faster for the backend to do it,
         # without passing back the probabilities.
         if num_samples == 1:
-            sample = sim.measure(measure_qubit)
+            sample = self._sim.measure(measure_qubit)
             classical_state = self._classical_memory
             for index in range(len(measure_qubit)):
                 qubit = measure_qubit[index]
@@ -745,7 +795,7 @@ class QasmSimulator(BaseBackend):
             return memory
 
         # Sample and convert to bit-strings
-        measure_results = sim.measure_shots(measure_qubit, num_samples)
+        measure_results = self._sim.measure_shots(measure_qubit, num_samples)
         classical_state = self._classical_memory
         for key, value in measure_results.items():
             sample = key
@@ -762,7 +812,7 @@ class QasmSimulator(BaseBackend):
         return memory
 
     #@profile
-    def _add_qasm_measure(self, sample_qubits, sample_clbits, sim, sample_cregbits=None):
+    def _add_qasm_measure(self, sample_qubits, sample_clbits, sample_cregbits=None):
         """Apply a measure instruction to a qubit.
         Args:
             qubit (int): qubit is the qubit measured.
@@ -774,7 +824,7 @@ class QasmSimulator(BaseBackend):
         measure_clbit = [clbit for sublist in sample_clbits for clbit in sublist]
         measure_cregbit = [clbit for sublist in sample_cregbits for clbit in sublist]
 
-        sample = sim.measure(measure_qubit)
+        sample = self._sim.measure(measure_qubit)
         classical_state = self._classical_memory
         classical_register = self._classical_register
         for index in range(len(measure_qubit)):

--- a/qiskit/providers/qrack/backends/wrappers/qrack_controller.hpp
+++ b/qiskit/providers/qrack/backends/wrappers/qrack_controller.hpp
@@ -82,18 +82,18 @@ public:
         qReg = MAKE_ENGINE(num_qubits, 0);
     }
 
-    virtual QrackController clone() {
-        QrackController c;
+    virtual QrackController* clone() {
+        QrackController* c = new QrackController();
 
-        c.deviceId = deviceId;
-        c.doNorm = doNorm;
-        c.amplitudeFloor = amplitudeFloor;
+        c->deviceId = deviceId;
+        c->doNorm = doNorm;
+        c->amplitudeFloor = amplitudeFloor;
 
-        c.qIType1 = qIType1;
-        c.qIType2 = qIType2;
-        c.qIType3 = qIType3;
+        c->qIType1 = qIType1;
+        c->qIType2 = qIType2;
+        c->qIType3 = qIType3;
 
-        c.qReg = qReg->Clone();
+        c->qReg = qReg->Clone();
 
         return c;
     }

--- a/qiskit/providers/qrack/backends/wrappers/qrack_controller_wrapper.pyx
+++ b/qiskit/providers/qrack/backends/wrappers/qrack_controller_wrapper.pyx
@@ -23,7 +23,7 @@ cdef extern from "qrack_controller.hpp" namespace "AER::Simulator":
     cdef cppclass QrackController:
         QrackController() except +
         void initialize_qreg(bool use_opencl, bool use_qunit, bool use_qpager, bool use_stabilizer, unsigned char num_qubits, int opencl_device_id, bool opencl_multi, bool doNormalize, double zero_threshold) except +
-        QrackController clone()
+        QrackController* clone()
         void u(unsigned char* bits, unsigned char bitCount, double* params)
         void u2(unsigned char* bits, unsigned char bitCount, double* params)
         void u1(unsigned char* bits, unsigned char bitCount, double* params)
@@ -80,7 +80,7 @@ cdef class PyQrackController:
     def clone(self):
         cdef PyQrackController py_obj = PyQrackController()
         # Set extension pointer to clone of existing C++ class ptr
-        py_obj.c_class[0] = self.c_class.clone()
+        py_obj.c_class = self.c_class.clone()
         return py_obj
 
     def u(self, bits, params):


### PR DESCRIPTION
Similar to how many Cirq simulator engines work, this splits QASM engine circuits into a unitary header and a non-unitary suffix. (There is a tradeoff in increased memory usage, for maintaining a clone of the simulator state at the end of the unitary header, but this is avoided if sampling could happen as before this PR.)