### PR TITLE
Remove unnecessary/deprecated import

### DIFF
--- a/test/terra/test_python_to_cpp.py
+++ b/test/terra/test_python_to_cpp.py
@@ -12,7 +12,6 @@
 
 import unittest
 import numpy as np
-from qiskit.providers.aer.pulse.qutip_extra_lite.qobj import Qobj
 from qiskit.providers.aer.pulse.controllers.test_python_to_cpp import \
     test_py_list_to_cpp_vec, test_py_list_of_lists_to_cpp_vector_of_vectors,\
     test_py_dict_string_numeric_to_cpp_map_string_numeric,\


### PR DESCRIPTION
For 0.25.0 support, this `import` is unnecessary and needs to be removed.